### PR TITLE
統合テストの環境設定

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -30,10 +30,14 @@ services:
     volumes:
       - "./services/api/:/app/"
       - "./openapi/:/openapi/"
+      - "/var/run/docker.sock:/var/run/docker.sock" #dockerのソケットを公開
     ports:
       - "${API_HTTP_HOST_PORT:-8080}:8080"
     environment:
       TZ: ${TZ}
+      TESTCONTAINERS_HOST_OVERRIDE: "host.docker.internal" # testcontainersが利用するhost
+    extra_hosts:
+      - "host.docker.internal:host-gateway" # Docker for Mac/Windowsの場合ホスト名の解決に必要
     depends_on:
       db-srv:
         condition: service_healthy

--- a/services/api/src/gradle/libs.versions.toml
+++ b/services/api/src/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ webp-imageio-version = "0.10.0"
 kotest-version = "5.9.1"
 ktor-server-swagger-version = "3.2.1"
 kotlinx-coroutines-version = "1.10.2"
-
+kotest-containers-version = "2.0.2"
 
 [libraries]
 # 基本的な機能拡張 基本的に単独で利用される想定　アルファベット順で並べたら管理しやすいか・・・？
@@ -73,6 +73,8 @@ koin-logger-slf4j = { module = "io.insert-koin:koin-logger-slf4j", version.ref =
 # test
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest-version" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest-version" }
+kotest-containers = { module = "io.kotest.extensions:kotest-extensions-testcontainers", version.ref = "kotest-containers-version" }
+
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin-version" }

--- a/services/api/src/modules/infrastructure/build.gradle.kts
+++ b/services/api/src/modules/infrastructure/build.gradle.kts
@@ -17,6 +17,8 @@ dependencies {
 
     // test
     testImplementation(libs.bundles.kotest.core)
+    testImplementation(libs.kotest.containers)
+    testImplementation(libs.jdbc.postgresql)    // テストコンテナをマイグレーションするときに必要
 
     // モジュールの関連付け
     implementation(project(":modules:domain"))

--- a/services/api/src/modules/infrastructure/src/test/kotlin/com/streview/infrastructure/database/TestContainerManeger.kt
+++ b/services/api/src/modules/infrastructure/src/test/kotlin/com/streview/infrastructure/database/TestContainerManeger.kt
@@ -1,0 +1,74 @@
+package com.streview.infrastructure.database
+
+import io.kotest.core.annotation.AutoScan
+import io.kotest.core.listeners.AfterProjectListener
+import io.kotest.core.listeners.BeforeProjectListener
+import io.kotest.extensions.testcontainers.ContainerExtension
+import io.r2dbc.spi.ConnectionFactories
+import io.r2dbc.spi.ConnectionFactory
+import io.r2dbc.spi.ConnectionFactoryOptions.*
+import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabaseConfig
+import org.jetbrains.exposed.v1.r2dbc.SchemaUtils
+import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
+import org.testcontainers.containers.GenericContainer
+
+/**
+ * テストコンテナとKotest拡張機能のインスタンスをシングルトンとして管理するオブジェクト。
+ * これにより、モジュール内の全テストで同じコンテナインスタンスを共有できる。
+ */
+object TestDatabaseManager {
+    //  PostgreSQLコンテナを定義
+    val postgresContainer = GenericContainer("postgres:15.13-bookworm").apply {
+        withExposedPorts(5432)
+        withEnv("POSTGRES_USER", "test")
+        withEnv("POSTGRES_PASSWORD", "test")
+        withEnv("POSTGRES_DB", "test")
+    }
+
+    // ContainerExtensionもシングルトンとして保持する
+    val dbExtension = ContainerExtension(postgresContainer)
+}
+
+@AutoScan
+object DatabaseSetupListener : BeforeProjectListener, AfterProjectListener {
+    override suspend fun beforeProject() {
+        // コンテナを起動させるために、一度だけダミーでインストールする
+        // これにより、TestDatabaseManager.postgresContainer が起動する
+        TestDatabaseManager.dbExtension.mount { }
+
+        // データベース接続とスキーマ作成を一度だけ実行
+        val postgres = TestDatabaseManager.postgresContainer
+        // 起動したコンテナの情報を元に接続情報を設定
+        val connectionFactory: ConnectionFactory = ConnectionFactories.get(
+            builder()
+                .option(DRIVER, "pool")
+                .option(PROTOCOL, "postgresql")
+                .option(HOST, postgres.host)
+                .option(PORT, postgres.firstMappedPort)
+                .option(USER, "test")
+                .option(PASSWORD, "test")
+                .option(DATABASE, "test")
+                .build()
+        )
+
+
+        // コネクションプールの作成
+        R2dbcDatabase.connect(
+            connectionFactory,
+            databaseConfig = R2dbcDatabaseConfig {
+                explicitDialect = PostgreSQLDialect()
+            }
+        )
+        // TODO:テーブル追加するよ
+//        suspendTransaction {
+//
+//        }
+    }
+
+    override suspend fun afterProject() {
+        // 全テスト終了後にコンテナを停止させる
+        TestDatabaseManager.postgresContainer.stop()
+    }
+}


### PR DESCRIPTION
close https://github.com/kimetaato/streview-sv/issues/47

ホスト上のDockerを利用するために必要なUnix domain socketをapiコンテナにバインドすることで、コンテナ内からホストのDockerを操作することができるようになる。

これを利用し、postgresSQLコンテナを立てるtest container manegerを追加
新たにテーブルを作成した場合、`beforeProject()`メソッド内でマイグレーションを実行することで、テストコンテナにテーブルを追加することができる。
