### PR TITLE
すれ違いを行ったときに、誰とすれ違ったか判断できるよ

### DIFF
--- a/services/api/src/modules/application/src/main/kotlin/com/streview/application/usecases/encounters/EncounterUseCase.kt
+++ b/services/api/src/modules/application/src/main/kotlin/com/streview/application/usecases/encounters/EncounterUseCase.kt
@@ -16,10 +16,10 @@ class EncounterUseCase(
         var encounterCount = 0
         // 日付ごとのエンティティで処理を行う
         input.encounters.map {
-            val encounter = eR.findByID(input.userID, it.encounterDate)
+            val encounter = eR.findByID(input.userID, it.date)
 
             // すれ違いを追加
-            it.encryptedEncounterIDs.forEach { encryptedEncounterID ->
+            it.encounter.forEach { encryptedEncounterID ->
                 // 暗号化されたencounterIDから実際のUserIDを抽出
                 val actualUserID = dS.extractUserID(encryptedEncounterID)
                 try {

--- a/services/api/src/modules/application/src/main/kotlin/com/streview/application/usecases/encounters/dto/EncounterDTO.kt
+++ b/services/api/src/modules/application/src/main/kotlin/com/streview/application/usecases/encounters/dto/EncounterDTO.kt
@@ -6,11 +6,11 @@ import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Serializable
 
 /**
- * @param encounterDate すれ違った日にち
- * @param encryptedEncounterIDs その日にすれ違ったユーザーの暗号化文字列
+ * @param date すれ違った日にち
+ * @param encounter その日にすれ違ったユーザーの暗号化文字列
  */
 @Serializable
-data class DailyEncounter(val encounterDate: LocalDate, val encryptedEncounterIDs: List<String>)
+data class DailyEncounter(val date: LocalDate, val encounter: List<String>)
 
 /**
  * すれ違いリクエストのDTO

--- a/services/api/src/modules/presentation/src/main/kotlin/com/streview/presentation/controller/EncounterController.kt
+++ b/services/api/src/modules/presentation/src/main/kotlin/com/streview/presentation/controller/EncounterController.kt
@@ -16,7 +16,7 @@ import org.koin.ktor.ext.inject
 fun Route.encounterController() {
     val encounterUseCase: EncounterUseCase by inject()
 
-    post("/encounter") {
+    post("/encounters") {
         @Serializable
         data class RequestJson(val encounters: List<DailyEncounter>)
 

--- a/services/api/src/modules/presentation/src/main/kotlin/com/streview/presentation/controller/EncounterController.kt
+++ b/services/api/src/modules/presentation/src/main/kotlin/com/streview/presentation/controller/EncounterController.kt
@@ -1,0 +1,37 @@
+package com.streview.presentation.controller
+
+import com.streview.application.usecases.encounters.EncounterUseCase
+import com.streview.application.usecases.encounters.dto.DailyEncounter
+import com.streview.application.usecases.encounters.dto.EncounterRequest
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.auth.UserIdPrincipal
+import io.ktor.server.auth.principal
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import kotlinx.serialization.Serializable
+import org.koin.ktor.ext.inject
+
+fun Route.encounterController() {
+    val encounterUseCase: EncounterUseCase by inject()
+
+    post("/encounter") {
+        @Serializable
+        data class RequestJson(val encounters: List<DailyEncounter>)
+
+        // ユーザー取得
+        val userID = call.principal<UserIdPrincipal>()!!.name
+
+        // json取得
+        val requestJson = call.receive<RequestJson>()
+
+        val req = EncounterRequest(
+            userID,
+            requestJson.encounters
+        )
+
+        val res = encounterUseCase.execute(req)
+        call.respond(HttpStatusCode.OK, res)
+    }
+}

--- a/services/api/src/modules/presentation/src/test/kotlin/com/streview/presentation/controller/EncounterControllerTest.kt
+++ b/services/api/src/modules/presentation/src/test/kotlin/com/streview/presentation/controller/EncounterControllerTest.kt
@@ -1,0 +1,162 @@
+package com.streview.presentation.controller
+
+import com.streview.application.usecases.encounters.EncounterUseCase
+import com.streview.application.usecases.encounters.dto.EncounterResponse
+import com.streview.domain.exceptions.InvalidInputException
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.*
+import io.ktor.server.testing.testApplication
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import org.koin.core.context.GlobalContext
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.ktor.plugin.Koin
+
+class EncounterControllerTest : FreeSpec({
+
+    beforeEach { if (GlobalContext.getOrNull() != null) stopKoin() }
+    afterEach { if (GlobalContext.getOrNull() != null) stopKoin() }
+
+    "正常系" - {
+        "有効なリクエストで200レスポンス" {
+            clearAllMocks()
+            val mockUseCase = mockk<EncounterUseCase>()
+            coEvery { mockUseCase.execute(any()) } returns EncounterResponse(2)
+
+            testApplication {
+                application {
+                    install(ContentNegotiation) { json() }
+                    install(Koin) { modules(module { single { mockUseCase } }) }
+                    install(Authentication) {
+                        bearer("firebase-auth") { authenticate { UserIdPrincipal("user123") } }
+                    }
+                    routing { authenticate("firebase-auth") { encounterController() } }
+                }
+
+                val response = client.post("/encounter") {
+                    header(HttpHeaders.Authorization, "Bearer test-token")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"encounters": [{"date": "2024-01-15", "encounter": ["enc1", "enc2"]}]}""")
+                }
+
+                response.status shouldBe HttpStatusCode.OK
+                response.bodyAsText() shouldBe """{"encounterCount":2}"""
+                coVerify(exactly = 1) { mockUseCase.execute(any()) }
+            }
+        }
+
+        "空のencounterリストで正常処理" {
+            clearAllMocks()
+            val mockUseCase = mockk<EncounterUseCase>()
+            coEvery { mockUseCase.execute(any()) } returns EncounterResponse(0)
+
+            testApplication {
+                application {
+                    install(ContentNegotiation) { json() }
+                    install(Koin) { modules(module { single { mockUseCase } }) }
+                    install(Authentication) {
+                        bearer("firebase-auth") { authenticate { UserIdPrincipal("user123") } }
+                    }
+                    routing { authenticate("firebase-auth") { encounterController() } }
+                }
+
+                val response = client.post("/encounter") {
+                    header(HttpHeaders.Authorization, "Bearer test-token")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"encounters": []}""")
+                }
+
+                response.status shouldBe HttpStatusCode.OK
+                response.bodyAsText() shouldBe """{"encounterCount":0}"""
+            }
+        }
+    }
+
+    "異常系" - {
+        "認証なしで401エラー" {
+            clearAllMocks()
+            val mockUseCase = mockk<EncounterUseCase>()
+
+            testApplication {
+                application {
+                    install(ContentNegotiation) { json() }
+                    install(Koin) { modules(module { single { mockUseCase } }) }
+                    install(Authentication) {
+                        bearer("firebase-auth") { authenticate { null } }
+                    }
+                    routing { authenticate("firebase-auth") { encounterController() } }
+                }
+
+                val response = client.post("/encounter") {
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"encounters": []}""")
+                }
+
+                response.status shouldBe HttpStatusCode.Unauthorized
+                coVerify(exactly = 0) { mockUseCase.execute(any()) }
+            }
+        }
+
+        "不正JSONで400エラー" {
+            clearAllMocks()
+            val mockUseCase = mockk<EncounterUseCase>()
+
+            testApplication {
+                application {
+                    install(ContentNegotiation) { json() }
+                    install(Koin) { modules(module { single { mockUseCase } }) }
+                    install(Authentication) {
+                        bearer("firebase-auth") { authenticate { UserIdPrincipal("user123") } }
+                    }
+                    routing { authenticate("firebase-auth") { encounterController() } }
+                }
+
+                val response = client.post("/encounter") {
+                    header(HttpHeaders.Authorization, "Bearer test-token")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"invalid": "json"}""")
+                }
+
+                response.status shouldBe HttpStatusCode.BadRequest
+                coVerify(exactly = 0) { mockUseCase.execute(any()) }
+            }
+        }
+
+        "UseCase例外で500エラー" {
+            clearAllMocks()
+            val mockUseCase = mockk<EncounterUseCase>()
+            coEvery { mockUseCase.execute(any()) } throws InvalidInputException("暗号化エラー")
+
+            testApplication {
+                application {
+                    install(ContentNegotiation) { json() }
+                    install(Koin) { modules(module { single { mockUseCase } }) }
+                    install(Authentication) {
+                        bearer("firebase-auth") { authenticate { UserIdPrincipal("user123") } }
+                    }
+                    routing { authenticate("firebase-auth") { encounterController() } }
+                }
+
+                val response = client.post("/encounter") {
+                    header(HttpHeaders.Authorization, "Bearer test-token")
+                    contentType(ContentType.Application.Json)
+                    setBody("""{"encounters": [{"date": "2024-01-15", "encounter": ["enc1"]}]}""")
+                }
+
+                response.status.value shouldBe 500
+                coVerify(exactly = 1) { mockUseCase.execute(any()) }
+            }
+        }
+    }
+})

--- a/services/api/src/modules/presentation/src/test/kotlin/com/streview/presentation/controller/EncounterControllerTest.kt
+++ b/services/api/src/modules/presentation/src/test/kotlin/com/streview/presentation/controller/EncounterControllerTest.kt
@@ -44,7 +44,7 @@ class EncounterControllerTest : FreeSpec({
                     routing { authenticate("firebase-auth") { encounterController() } }
                 }
 
-                val response = client.post("/encounter") {
+                val response = client.post("/encounters") {
                     header(HttpHeaders.Authorization, "Bearer test-token")
                     contentType(ContentType.Application.Json)
                     setBody("""{"encounters": [{"date": "2024-01-15", "encounter": ["enc1", "enc2"]}]}""")
@@ -71,7 +71,7 @@ class EncounterControllerTest : FreeSpec({
                     routing { authenticate("firebase-auth") { encounterController() } }
                 }
 
-                val response = client.post("/encounter") {
+                val response = client.post("/encounters") {
                     header(HttpHeaders.Authorization, "Bearer test-token")
                     contentType(ContentType.Application.Json)
                     setBody("""{"encounters": []}""")
@@ -98,7 +98,7 @@ class EncounterControllerTest : FreeSpec({
                     routing { authenticate("firebase-auth") { encounterController() } }
                 }
 
-                val response = client.post("/encounter") {
+                val response = client.post("/encounters") {
                     contentType(ContentType.Application.Json)
                     setBody("""{"encounters": []}""")
                 }
@@ -122,7 +122,7 @@ class EncounterControllerTest : FreeSpec({
                     routing { authenticate("firebase-auth") { encounterController() } }
                 }
 
-                val response = client.post("/encounter") {
+                val response = client.post("/encounters") {
                     header(HttpHeaders.Authorization, "Bearer test-token")
                     contentType(ContentType.Application.Json)
                     setBody("""{"invalid": "json"}""")
@@ -148,7 +148,7 @@ class EncounterControllerTest : FreeSpec({
                     routing { authenticate("firebase-auth") { encounterController() } }
                 }
 
-                val response = client.post("/encounter") {
+                val response = client.post("/encounters") {
                     header(HttpHeaders.Authorization, "Bearer test-token")
                     contentType(ContentType.Application.Json)
                     setBody("""{"encounters": [{"date": "2024-01-15", "encounter": ["enc1"]}]}""")


### PR DESCRIPTION
close #100

# EP仕様
## Request
path: `/encounters`
method: POST
request body: application/json
```
"encounters" [
  {
    "date": "2006-01-02",
    "encounter": ["hogehoge", "fugafuga",,,,]
  },,,,
]
```
## Response
### Success
status code: 200
```
"encounterCount": 2 // すれ違いに成功した回数
```

### Failure
status code: 400, 401, 500


