### PR TITLE
[add] Result型を導入

### DIFF
--- a/services/api/src/config/detekt.yml
+++ b/services/api/src/config/detekt.yml
@@ -14,6 +14,9 @@ complexity:
   ComplexCondition: # 複雑すぎる条件式を検出
     active: true
     threshold: 5 # 閾値を4から5に緩和 (デフォルトは4)
+  LongParameterList:
+    constructorThreshold: 10
+    functionThreshold: 10 # 関数の引数の上限を8に修正 引数のパラメータ数の制限によって、エンティティの生成の引数にdata classなどを別途定義する昼用が出てくるため
 
 # 空のコードブロックに関する問題
 empty-blocks:

--- a/services/api/src/config/detekt.yml
+++ b/services/api/src/config/detekt.yml
@@ -15,8 +15,8 @@ complexity:
     active: true
     threshold: 5 # 閾値を4から5に緩和 (デフォルトは4)
   LongParameterList:
-  constructorThreshold: 10
-  functionThreshold: 10 # 関数の引数の上限を10に修正 引数のパラメータ数の制限によって、エンティティの生成の引数にdata classなどを別途定義する昼用が出てくるため
+    constructorThreshold: 10
+    functionThreshold: 10 # 関数の引数の上限を10に修正 引数のパラメータ数の制限によって、エンティティの生成の引数にdata classなどを別途定義する昼用が出てくるため
 # 空のコードブロックに関する問題
 empty-blocks:
   active: true

--- a/services/api/src/modules/domain/build.gradle.kts
+++ b/services/api/src/modules/domain/build.gradle.kts
@@ -8,10 +8,9 @@ dependencies {
     implementation(libs.kotlinx.cotoutines)
     implementation(libs.kotlinx.datetime)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlin.result)
     implementation(libs.uuid)
 
     // test
     testImplementation(libs.bundles.kotest.core)
 }
-
-

--- a/services/api/src/modules/domain/src/main/kotlin/com/streview/domain/commons/errors/DomainError.kt
+++ b/services/api/src/modules/domain/src/main/kotlin/com/streview/domain/commons/errors/DomainError.kt
@@ -1,0 +1,72 @@
+package com.streview.domain.commons.errors
+
+sealed class DomainError() : Throwable() {
+    override val message: String? = "Domain Error" // HACK: StatusPageによって一括でエラーハンドリングをするために継承。責務の観点から見ると綺麗な実装ではない
+    override val cause: Throwable? = null
+}
+
+enum class InvalidFormatRules {
+    PATTERN_MISMATCH, // パターンに一致していない
+    NOT_NUMERIC, // 数値ではない
+    NOT_ALPHANUMERIC, // 英数字のみでない
+    INVALID_DATE_TIME, // 日付がおかしいよ
+    TOO_LONG, // 長すぎる
+    TOO_SHORT, // 短すぎる
+    // 必要に応じて他のルールを追加
+}
+
+/**
+ * バリデーション時に発生するエラーを定義したクラス。
+ * 複数のバリデーションを同時に行う場合はMultipleにエラーを収集する
+ */
+sealed class ValidationError : DomainError() {
+    data class Required(val fieldName: String) : ValidationError()
+    data class InvalidFormat(val fieldName: String, val rule: InvalidFormatRules, val value: Any) : ValidationError()
+    data class Multiple(val errors: List<ValidationError>) : ValidationError()
+
+    fun toFlatValidationErrors(): List<ValidationError> {
+        return when (this) {
+            is Multiple -> this.errors.flatMap { it.toFlatValidationErrors() }
+            else -> listOf(this)
+        }
+    }
+}
+
+/**
+ * ドメインのルール上の制約を満たさない場合に発生するエラーを定義する。
+ */
+sealed class BusinessRuleError : DomainError() {
+    object NotFound : BusinessRuleError()
+}
+
+/**
+ * エンティティのライフサイクル上不可能な状態の場合に発生するエラー
+ */
+sealed class EntityError : DomainError() {
+    data class NotFound(val type: String) : EntityError()
+    object AlreadyExist : EntityError()
+}
+
+/**
+ * 技術的なエラーを抽象的なドメインのエラーとして扱う
+ */
+sealed class TechnicalError : DomainError() {
+    data class DatabaseError(
+        val isConnectionIssue: Boolean = false,
+        override val cause: Throwable? = null
+    ) : TechnicalError()
+
+    // ネットワーク関連の問題
+    data class NetworkError(
+        val serviceName: String,
+        val isTimeout: Boolean = false,
+        override val cause: Throwable? = null,
+    ) : TechnicalError()
+
+    // 外部サービス関連の問題
+    data class ExternalServiceError(
+        val serviceName: String,
+        override val cause: Throwable? = null,
+        val statusCode: Int? = null
+    ) : TechnicalError()
+}

--- a/services/api/src/modules/domain/src/main/kotlin/com/streview/domain/commons/result/ResultBuilder.kt
+++ b/services/api/src/modules/domain/src/main/kotlin/com/streview/domain/commons/result/ResultBuilder.kt
@@ -1,0 +1,163 @@
+package com.streview.domain.commons.result
+
+import com.github.michaelbull.result.Result
+import com.streview.domain.commons.errors.ValidationError
+
+// =============================================================================
+// build函数のオーバーロード（1個〜6個）
+// Value Objectを材料にエンティティを構築する
+// 内部実装は共通のResultCombinerを使用
+// =============================================================================
+
+/**
+ * 2つのResultからエンティティを構築する
+ */
+@Suppress("UNCHECKED_CAST")
+inline fun <T1, T2, R> build(
+    result1: Result<T1, ValidationError>,
+    result2: Result<T2, ValidationError>,
+    crossinline transform: (T1, T2) -> R
+): Result<R, ValidationError> {
+    return ResultCombiner()
+        .add(result1)
+        .add(result2)
+        .build { values ->
+            transform(values[0] as T1, values[1] as T2)
+        }
+}
+
+/**
+ * 3つのResultを組み合わせる
+ */
+@Suppress("UNCHECKED_CAST")
+inline fun <T1, T2, T3, R> build(
+    result1: Result<T1, ValidationError>,
+    result2: Result<T2, ValidationError>,
+    result3: Result<T3, ValidationError>,
+    crossinline transform: (T1, T2, T3) -> R
+): Result<R, ValidationError> {
+    return ResultCombiner()
+        .add(result1)
+        .add(result2)
+        .add(result3)
+        .build { values ->
+            transform(values[0] as T1, values[1] as T2, values[2] as T3)
+        }
+}
+
+/**
+ * 4つのResultを組み合わせる
+ */
+@Suppress("UNCHECKED_CAST")
+inline fun <T1, T2, T3, T4, R> build(
+    result1: Result<T1, ValidationError>,
+    result2: Result<T2, ValidationError>,
+    result3: Result<T3, ValidationError>,
+    result4: Result<T4, ValidationError>,
+    crossinline transform: (T1, T2, T3, T4) -> R
+): Result<R, ValidationError> {
+    return ResultCombiner()
+        .add(result1)
+        .add(result2)
+        .add(result3)
+        .add(result4)
+        .build { values ->
+            transform(values[0] as T1, values[1] as T2, values[2] as T3, values[3] as T4)
+        }
+}
+
+/**
+ * 5つのResultを組み合わせる
+ */
+@Suppress("UNCHECKED_CAST")
+inline fun <T1, T2, T3, T4, T5, R> build(
+    result1: Result<T1, ValidationError>,
+    result2: Result<T2, ValidationError>,
+    result3: Result<T3, ValidationError>,
+    result4: Result<T4, ValidationError>,
+    result5: Result<T5, ValidationError>,
+    crossinline transform: (T1, T2, T3, T4, T5) -> R
+): Result<R, ValidationError> {
+    return ResultCombiner()
+        .add(result1)
+        .add(result2)
+        .add(result3)
+        .add(result4)
+        .add(result5)
+        .build { values ->
+            transform(
+                values[0] as T1,
+                values[1] as T2,
+                values[2] as T3,
+                values[3] as T4,
+                values[4] as T5
+            )
+        }
+}
+
+/**
+ * 6つのResultを組み合わせる
+ */
+@Suppress("UNCHECKED_CAST")
+inline fun <T1, T2, T3, T4, T5, T6, R> build(
+    result1: Result<T1, ValidationError>,
+    result2: Result<T2, ValidationError>,
+    result3: Result<T3, ValidationError>,
+    result4: Result<T4, ValidationError>,
+    result5: Result<T5, ValidationError>,
+    result6: Result<T6, ValidationError>,
+    crossinline transform: (T1, T2, T3, T4, T5, T6) -> R
+): Result<R, ValidationError> {
+    return ResultCombiner()
+        .add(result1)
+        .add(result2)
+        .add(result3)
+        .add(result4)
+        .add(result5)
+        .add(result6)
+        .build { values ->
+            transform(
+                values[0] as T1,
+                values[1] as T2,
+                values[2] as T3,
+                values[3] as T4,
+                values[4] as T5,
+                values[5] as T6
+            )
+        }
+}
+
+/**
+ * 6つのResultを組み合わせる
+ */
+@Suppress("UNCHECKED_CAST")
+inline fun <T1, T2, T3, T4, T5, T6, T7, R> build(
+    result1: Result<T1, ValidationError>,
+    result2: Result<T2, ValidationError>,
+    result3: Result<T3, ValidationError>,
+    result4: Result<T4, ValidationError>,
+    result5: Result<T5, ValidationError>,
+    result6: Result<T6, ValidationError>,
+    result7: Result<T7, ValidationError>,
+    crossinline transform: (T1, T2, T3, T4, T5, T6, T7) -> R
+): Result<R, ValidationError> {
+    return ResultCombiner()
+        .add(result1)
+        .add(result2)
+        .add(result3)
+        .add(result4)
+        .add(result5)
+        .add(result6)
+        .add(result7)
+        .build { values ->
+            transform(
+                values[0] as T1,
+                values[1] as T2,
+                values[2] as T3,
+                values[3] as T4,
+                values[4] as T5,
+                values[5] as T6,
+                values[6] as T7
+            )
+        }
+}

--- a/services/api/src/modules/domain/src/main/kotlin/com/streview/domain/commons/result/ResultCombiner.kt
+++ b/services/api/src/modules/domain/src/main/kotlin/com/streview/domain/commons/result/ResultCombiner.kt
@@ -1,0 +1,41 @@
+package com.streview.domain.commons.result
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.streview.domain.commons.errors.ValidationError
+
+/**
+ * 可変長引数でResultを組み合わせるビルダークラス
+ * 型安全性を保ちながら複数のResultを組み合わせる
+ */
+class ResultCombiner {
+    private val values = mutableListOf<Any?>()
+    private val errors = mutableListOf<ValidationError>()
+
+    /**
+     * Resultを追加する
+     * エラーの場合は、エラーをフラットなリストとして `errors` に追加します。
+     */
+    fun <T> add(result: Result<T, ValidationError>): ResultCombiner {
+        if (result.isErr) {
+            // エラーであれば、そのエラーをフラットな形式で errors リストに追加
+            errors.addAll(result.error.toFlatValidationErrors())
+        } else {
+            // 成功の場合は値を values リストに追加
+            values.add(result.value)
+        }
+        return this
+    }
+
+    /**
+     * すべてのResultを組み合わせて最終結果を生成
+     */
+    fun <R> build(transform: (List<Any?>) -> R): Result<R, ValidationError> {
+        return if (errors.isEmpty()) {
+            Ok(transform(values))
+        } else {
+            Err(if (errors.size == 1) errors.first() else ValidationError.Multiple(errors))
+        }
+    }
+}


### PR DESCRIPTION
close #103 
Ruslt型を利用して例外を処理したいです。

エラーハンドリングを簡略化するためのヘルパー関数を実装済み。
voから集約を生成する際に利用する

StatusPageで例外を一括してハンドリングするためにExceptionクラスを継承している。
責務の観点からは微妙
- Application層でExceptionでラップ
- Presentation層でラップ
- StatusPageでは処理を行わず、Presentation層の共通関数によってハンドリング
のいずれかが適切か、、、？

わからないよ〜〜〜〜〜〜〜〜〜〜〜〜〜〜